### PR TITLE
Exclude unnecessary files from gem

### DIFF
--- a/connect_proto.gemspec
+++ b/connect_proto.gemspec
@@ -16,7 +16,11 @@ Gem::Specification.new do |s|
   s.description = "Protobufs for Diagnostic Ordering and Resulting"
   s.license     = "Unlicense"
   s.required_ruby_version = ">= 2.4"
-  s.files       = `find *`.split("\n").uniq.sort.select { |f| !f.empty? }
+  s.files = Dir.chdir(File.expand_path(__dir__)) do
+    `git ls-files -z`.split("\x0").reject do |f|
+      (f == __FILE__) || f.match(%r{\A(?:(?:test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
+    end
+  end
   s.require_paths = ["lib", "lib/connect_proto/build", "lib/extensions"]
   s.executables = []
 


### PR DESCRIPTION
Using bundler's gem scaffolding makes sure .gitignore is honored
![image](https://user-images.githubusercontent.com/484865/221057569-a8dc50af-68e8-48b3-ac21-9e76c58462ec.png)
