### PR TITLE
expand CodedValue with alt fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Change Log
 
+## 0.26.0
+
+- Update `Order.procedure` to include alternate fields
+
 ## 0.25.0
 
-- Update `google-protobuf` to 3.25.5 (security update) 
+- Update `google-protobuf` to 3.25.5 (security update)
 
 ## 0.24.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     byebug (11.1.3)
     coderay (1.1.3)
     diff-lcs (1.5.1)
-    google-protobuf (3.25.5-arm64-darwin)
+    google-protobuf (3.25.5)
     json (2.9.0)
     language_server-protocol (3.17.0.3)
     method_source (1.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    primary_connect_proto (0.25.0)
+    primary_connect_proto (0.26.0)
       google-protobuf (~> 3.25.5)
 
 GEM
@@ -11,7 +11,7 @@ GEM
     byebug (11.1.3)
     coderay (1.1.3)
     diff-lcs (1.5.1)
-    google-protobuf (3.25.5)
+    google-protobuf (3.25.5-arm64-darwin)
     json (2.9.0)
     language_server-protocol (3.17.0.3)
     method_source (1.1.0)

--- a/lib/connect_proto/src/coded_value.proto
+++ b/lib/connect_proto/src/coded_value.proto
@@ -6,4 +6,10 @@ message CodedValue {
   string value = 1;
   string code_set = 2;
   string description = 3;
+  string alt_value = 4;
+  string alt_code_set = 5;
+  string alt_description = 6;
+  string code_set_version = 7;
+  string alt_code_set_version = 8;
+  string original_text = 9:
 }

--- a/lib/connect_proto/version.rb
+++ b/lib/connect_proto/version.rb
@@ -1,3 +1,3 @@
 module ConnectProto
-  VERSION = '0.25.0'
+  VERSION = '0.26.0'
 end


### PR DESCRIPTION
To accommodate San Diego, we need to store values sent in OBR-4.5 for ORMs. When we send them results (ORU), the OBX-3.5 needs to match what they sent us in OBR-4.5 from the original order.

Since `order.procedure` is built using the `CodedValue` proto, we should expand `CodedValue` to support alternate fields to store alt identifiers/info.