### PR TITLE
add values from HL7 table 0078 to the AbnormalFlag enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.27.0
+
+- Update `Result.abnormal_flag` enum to include all values from HL7 table 0078
+
 ## 0.26.0
 
 - Update `Order.procedure` to include alternate fields

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    primary_connect_proto (0.26.0)
+    primary_connect_proto (0.27.0)
       google-protobuf (~> 3.25.5)
 
 GEM
@@ -11,7 +11,7 @@ GEM
     byebug (11.1.3)
     coderay (1.1.3)
     diff-lcs (1.5.1)
-    google-protobuf (3.25.5)
+    google-protobuf (3.25.5-arm64-darwin)
     json (2.9.0)
     language_server-protocol (3.17.0.3)
     method_source (1.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     byebug (11.1.3)
     coderay (1.1.3)
     diff-lcs (1.5.1)
-    google-protobuf (3.25.5-arm64-darwin)
+    google-protobuf (3.25.5)
     json (2.9.0)
     language_server-protocol (3.17.0.3)
     method_source (1.1.0)

--- a/lib/connect_proto/src/result.proto
+++ b/lib/connect_proto/src/result.proto
@@ -52,6 +52,12 @@ message Result {
     INCONCLUSIVE = 15;
     VERY_ABNORMAL = 16;
     NORMAL = 17;
+    ABOVE_ABSOLUTE_HIGH = 18;
+    BELOW_ABSOLUTE_LOW = 19;
+    BETTER = 20;
+    SIGNIFICANT_CHANGE_DOWN = 21;
+    SIGNIFICANT_CHANGE_UP = 22;
+    WORSE = 23;
   }
 
   enum Status {

--- a/lib/connect_proto/version.rb
+++ b/lib/connect_proto/version.rb
@@ -1,3 +1,3 @@
 module ConnectProto
-  VERSION = '0.26.0'
+  VERSION = '0.27.0'
 end


### PR DESCRIPTION
Discrepancy between [possible HL7 values](https://hl7-definition.caristix.com/v2/HL7v2.6/Tables/0078) for `abnormal_flag` for results. Yes, that link is just a "suggested" table and that OBX-8 is technically a user-defined field, but we still ought to expand the enum to include more values. I don't think the values I'm adding are all that fringe either, seems likely that at least _some_ labs would send us values like these at some point.