### PR TITLE
Remove references to deleted Formattable Extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.30.1
+
+-- Remove all references of `'formattable/coded_value'`
+
 ## 0.30.0
 
 -- Remove `Extensions::Formattable::CodedValue` module

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    primary_connect_proto (0.30.0)
+    primary_connect_proto (0.30.1)
       google-protobuf (~> 3.25.7)
 
 GEM

--- a/lib/connect_proto/version.rb
+++ b/lib/connect_proto/version.rb
@@ -1,3 +1,3 @@
 module ConnectProto
-  VERSION = '0.30.0'.freeze
+  VERSION = '0.30.1'.freeze
 end

--- a/lib/primary_connect_proto.rb
+++ b/lib/primary_connect_proto.rb
@@ -22,10 +22,8 @@ require 'visit_pb'
 require 'full_nameable'
 require 'phone_numberable'
 require 'valueable'
-require 'formattable/coded_value'
 
 Primary::Connect::Name.include(ConnectProto::Extensions::FullNameable)
-Primary::Connect::CodedValue.include(ConnectProto::Extensions::Formattable::CodedValue)
 [
   Primary::Connect::Provider,
   Primary::Connect::Demographics,


### PR DESCRIPTION
Remove statements that load/require the deleted Formattable extension for CodedValue